### PR TITLE
fix: sanitize user markdown (XSS) and harden Mermaid

### DIFF
--- a/docs/MARKDOWN_XSS.md
+++ b/docs/MARKDOWN_XSS.md
@@ -1,0 +1,19 @@
+# Markdown XSS controls
+
+User and Nostr-sourced markdown (READMEs, repo files, About text, issue/PR bodies,
+discussion body + comments) is rendered with `react-markdown` + `rehype-raw`
+**and** `rehype-sanitize` via the shared helper:
+
+`ui/src/lib/security/markdown-rehype-plugins.ts`
+
+Never use `rehypeRaw` alone on those paths. Custom `components` (`code` / `img` / `a`)
+are not a substitute for sanitization.
+
+Mermaid fenced blocks go through `MermaidRenderer` with
+`securityLevel: "antiscript"` (not `"loose"`).
+
+CSP in `ui/next.config.js` still allows `'unsafe-inline'` / `'unsafe-eval'` for
+Next/runtime needs. Sanitize is the primary XSS control for markdown; tightening
+CSP is a separate follow-up.
+
+Unit coverage: `ui/src/lib/security/markdown-rehype-plugins.test.ts`.

--- a/docs/SETUP_INSTRUCTIONS.md
+++ b/docs/SETUP_INSTRUCTIONS.md
@@ -17,6 +17,7 @@ Install gittr (Next.js UI + API) and **git-nostr-bridge** on a Linux server. Pat
 | GitHub OAuth | [ui/GITHUB_OAUTH_SETUP.md](../ui/GITHUB_OAUTH_SETUP.md) |
 | Pages gateway + wildcard DNS/TLS | [infra/nsite-gateway/README.md](../infra/nsite-gateway/README.md) |
 | SEO / sitemap | [SEO.md](SEO.md) |
+| Markdown XSS / rehype-sanitize | [MARKDOWN_XSS.md](MARKDOWN_XSS.md) |
 | Event kinds / paywall product rules | [NIPS_AND_EVENT_KINDS.md](NIPS_AND_EVENT_KINDS.md) |
 | Web of Trust badges | [WOT.md](WOT.md) |
 | Local dev | [LOCAL_SETUP.md](LOCAL_SETUP.md) |

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "prettier": "prettier src/**/*.{ts,tsx} --write",
     "eslint": "eslint --ext .ts,.tsx --fix .",
-    "test:unit": "npx vitest run src/lib/git/bare-repo-tree-last-commits.test.ts src/lib/utils/filter-display-clone-urls.test.ts src/lib/nostr/should-announce-upstream-tip.test.ts src/lib/repos/repo-file-tree-branch.test.ts src/lib/repos/forge-tree-shrink.test.ts",
+    "test:unit": "npx vitest run src/lib/git/bare-repo-tree-last-commits.test.ts src/lib/utils/filter-display-clone-urls.test.ts src/lib/nostr/should-announce-upstream-tip.test.ts src/lib/repos/repo-file-tree-branch.test.ts src/lib/repos/forge-tree-shrink.test.ts src/lib/security/markdown-rehype-plugins.test.ts",
     "test:regressions": "npm run test:unit",
     "delete:nostr-relaypool-ts": "rimraf ./node_modules/nostr-relaypool/*.ts",
     "generate-system-keypair": "node scripts/generate-system-keypair.js"
@@ -48,7 +48,8 @@
     "tailwindcss-animate": "^1.0.5",
     "utf-8-validate": "^6.0.5",
     "ws": "^8.21.0",
-    "zod": "^3.20.6"
+    "zod": "^3.25.76",
+    "rehype-sanitize": "^6.0.0"
   },
   "devDependencies": {
     "@capacitor/android": "^7.4.4",
@@ -72,7 +73,8 @@
     "rimraf": "^4.3.1",
     "tailwind-scrollbar": "^2.1.0",
     "tailwindcss": "^3.2.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "rehype-stringify": "^10.0.1"
   },
   "ct3aMetadata": {
     "initVersion": "7.5.9"

--- a/ui/src/app/[entity]/[repo]/architecture/page.tsx
+++ b/ui/src/app/[entity]/[repo]/architecture/page.tsx
@@ -93,7 +93,7 @@ export default function ArchitecturePage({
             fontFamily:
               "ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif",
           },
-          securityLevel: "loose",
+          securityLevel: "antiscript",
           flowchart: {
             useMaxWidth: false,
             htmlLabels: true,

--- a/ui/src/app/[entity]/[repo]/discussions/[id]/page.tsx
+++ b/ui/src/app/[entity]/[repo]/discussions/[id]/page.tsx
@@ -27,8 +27,8 @@ import { MarkdownCode } from "@/lib/utils/markdown-code";
 import { ArrowLeft, MessageCircle, Reply } from "lucide-react";
 import Link from "next/link";
 import { getEventHash } from "nostr-tools";
+import { markdownRehypePlugins } from "@/lib/security/markdown-rehype-plugins";
 import ReactMarkdown from "react-markdown";
-import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 
 type ThreadedComment = DiscussionComment & {
@@ -272,7 +272,7 @@ export default function DiscussionDetailPage({
               <div className="prose prose-invert max-w-none text-sm mb-3">
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
+                  rehypePlugins={markdownRehypePlugins}
                   components={{
                     code: MarkdownCode,
                   }}
@@ -375,7 +375,7 @@ export default function DiscussionDetailPage({
             <div className="prose prose-invert max-w-none">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
+                rehypePlugins={markdownRehypePlugins}
                 components={{
                   code: MarkdownCode,
                 }}

--- a/ui/src/app/[entity]/[repo]/issues/[id]/page.tsx
+++ b/ui/src/app/[entity]/[repo]/issues/[id]/page.tsx
@@ -89,8 +89,8 @@ import { Reply } from "lucide-react";
 import Link from "next/link";
 import { type UnsignedEvent, nip19 } from "nostr-tools";
 import { getEventHash, getPublicKey, signEvent } from "nostr-tools";
+import { markdownRehypePlugins } from "@/lib/security/markdown-rehype-plugins";
 import ReactMarkdown from "react-markdown";
-import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 
 interface Issue {
@@ -1713,7 +1713,7 @@ export default function IssueDetailPage({
             <div className="prose prose-invert max-w-none mb-4">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
+                rehypePlugins={markdownRehypePlugins}
                 components={{
                   code: MarkdownCode,
                 }}

--- a/ui/src/app/[entity]/[repo]/pulls/[id]/page.tsx
+++ b/ui/src/app/[entity]/[repo]/pulls/[id]/page.tsx
@@ -86,8 +86,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { nip19 } from "nostr-tools";
 import { getEventHash } from "nostr-tools";
+import { markdownRehypePlugins } from "@/lib/security/markdown-rehype-plugins";
 import ReactMarkdown from "react-markdown";
-import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 
 interface ChangedFile {
@@ -2062,7 +2062,7 @@ export default function PRDetailPage({
             <div className="prose prose-invert max-w-none mb-4">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
+                rehypePlugins={markdownRehypePlugins}
                 components={{
                   code: MarkdownCode,
                 }}

--- a/ui/src/app/help/page.tsx
+++ b/ui/src/app/help/page.tsx
@@ -124,7 +124,7 @@ export default function HelpPage() {
             nodeBorder: "#7c3aed",
             nodeTextColor: "#fff",
           },
-          securityLevel: "loose",
+          securityLevel: "antiscript",
           flowchart: {
             useMaxWidth: false,
             htmlLabels: true,

--- a/ui/src/components/repo/RepoCodePage.tsx
+++ b/ui/src/components/repo/RepoCodePage.tsx
@@ -240,8 +240,8 @@ import {
   useSearchParams,
 } from "next/navigation";
 import { nip19 } from "nostr-tools";
+import { markdownRehypePlugins } from "@/lib/security/markdown-rehype-plugins";
 import ReactMarkdown from "react-markdown";
-import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 
 /** After Nostr refetch (full reload), resume README gittr block + Push to Nostr. */
@@ -17754,7 +17754,7 @@ export function RepoCodePage() {
                   >
                     <ReactMarkdown
                       remarkPlugins={[remarkGfm]}
-                      rehypePlugins={[rehypeRaw]}
+                      rehypePlugins={markdownRehypePlugins}
                       components={{
                         ...readmeHeadingComponents,
                         ...markdownProseCodeSafeComponents,
@@ -18382,7 +18382,7 @@ export function RepoCodePage() {
                       >
                         <ReactMarkdown
                           remarkPlugins={[remarkGfm]}
-                          rehypePlugins={[rehypeRaw]}
+                          rehypePlugins={markdownRehypePlugins}
                           components={{
                             ...fileHeadingComponents,
                             ...markdownProseCodeSafeComponents,
@@ -18703,7 +18703,7 @@ export function RepoCodePage() {
             sidebarAboutText(repoData?.description, resolvedParams.repo) ? (
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
+                rehypePlugins={markdownRehypePlugins}
                 components={{
                   a: repoDescriptionMarkdownAnchor,
                 }}

--- a/ui/src/components/ui/mermaid-renderer.tsx
+++ b/ui/src/components/ui/mermaid-renderer.tsx
@@ -16,7 +16,7 @@ function getMermaid() {
       const mermaid = mod.default;
       mermaid.initialize({
         startOnLoad: false,
-        securityLevel: "loose",
+        securityLevel: "antiscript",
         theme: "dark",
         // Dark theme forces light labels; our host highlights need dark fills + light text
         // that survive theme CSS. !important beats Mermaid’s default node fills.

--- a/ui/src/lib/security/markdown-rehype-plugins.test.ts
+++ b/ui/src/lib/security/markdown-rehype-plugins.test.ts
@@ -1,0 +1,40 @@
+import rehypeStringify from "rehype-stringify";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+
+import { markdownRehypePlugins } from "./markdown-rehype-plugins";
+
+async function renderMarkdown(md: string): Promise<string> {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(markdownRehypePlugins as any)
+    .use(rehypeStringify)
+    .process(md);
+  return String(file);
+}
+
+describe("markdownRehypePlugins", () => {
+  it("strips script tags from raw HTML in markdown", async () => {
+    const html = await renderMarkdown(
+      "Hello <script>alert(1)</script><b>world</b>"
+    );
+    expect(html).not.toMatch(/<script/i);
+    expect(html).toContain("<b>world</b>");
+  });
+
+  it("strips inline event handlers", async () => {
+    const html = await renderMarkdown(
+      '<img src="https://example.com/a.png" onerror="alert(1)" alt="x">'
+    );
+    expect(html).not.toMatch(/onerror/i);
+    expect(html).toMatch(/<img/i);
+  });
+
+  it("keeps language class on fenced code for mermaid routing", async () => {
+    const html = await renderMarkdown("```mermaid\ngraph TD; A-->B;\n```");
+    expect(html).toMatch(/language-mermaid/);
+  });
+});

--- a/ui/src/lib/security/markdown-rehype-plugins.ts
+++ b/ui/src/lib/security/markdown-rehype-plugins.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared rehype pipeline for user/Nostr-sourced markdown.
+ *
+ * Always pair rehype-raw with rehype-sanitize. Raw alone injects arbitrary
+ * HTML into the React tree (XSS). Sanitize uses GitHub-style defaults and
+ * keeps className on code/pre so fenced language-* (incl. mermaid) still works.
+ */
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+
+const markdownSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [...(defaultSchema.attributes?.code || []), ["className"], ["class"]],
+    pre: [...(defaultSchema.attributes?.pre || []), ["className"], ["class"]],
+    span: [...(defaultSchema.attributes?.span || []), ["className"], ["class"]],
+  },
+};
+
+/** Use as: rehypePlugins={markdownRehypePlugins} — never rehypeRaw alone. */
+export const markdownRehypePlugins: [
+  typeof rehypeRaw,
+  [typeof rehypeSanitize, typeof markdownSanitizeSchema]
+] = [rehypeRaw, [rehypeSanitize, markdownSanitizeSchema]];

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3483,6 +3483,32 @@ hast-util-raw@^9.0.0:
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
 
+hast-util-sanitize@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz#edb260d94e5bba2030eb9375790a8753e5bf391f"
+  integrity sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    unist-util-position "^5.0.0"
+
+hast-util-to-html@^9.0.0:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz"
@@ -5328,6 +5354,23 @@ rehype-raw@^7.0.0:
     hast-util-raw "^9.0.0"
     vfile "^6.0.0"
 
+rehype-sanitize@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz#16e95f4a67a69cbf0f79e113c8e0df48203db73c"
+  integrity sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-sanitize "^5.0.0"
+
+rehype-stringify@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-10.0.1.tgz#2ec1ebc56c6aba07905d3b4470bdf0f684f30b75"
+  integrity sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-to-html "^9.0.0"
+    unified "^11.0.0"
+
 remark-gfm@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz"
@@ -6336,12 +6379,12 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.20.6:
-  version "3.21.0"
-  resolved "https://registry.npmjs.org/zod/-/zod-3.21.0.tgz"
-  integrity sha512-UYdykTcVxB6lfdyLzAqLyyYAlOcpoluECvjsdoaqfQmz9p+3LRaIqYcNiL/J2kFYp66fBM8wwBvIGVEjq7KtZw==
+zod@^3.25.76:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-zwitch@^2.0.0:
+zwitch@^2.0.0, zwitch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz"
   integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
## Summary
- Pair `rehype-raw` with `rehype-sanitize` on all untrusted ReactMarkdown sinks (README, md files, About, issues, PRs, discussions) via shared `markdownRehypePlugins`
- Mermaid `securityLevel`: `loose` → `antiscript`
- Bump `zod` to `^3.25.76` (clears GHSA-m95q-7qp3-xv42 range used by scanners)
- Docs: `docs/MARKDOWN_XSS.md` + SETUP index link
- Unit tests for script/`onerror` stripping

## Test plan
- [x] `cd ui && yarn test:unit` (25 tests)
- [x] Live smoke: `/`, `/explore`, `/api/explore/seed`, issue `#34` markdown headings/lists/links render
- [ ] Spot-check a README and a discussion after merge