### PR TITLE
fix: show relative README images on Nostr/GRASP repos

### DIFF
--- a/docs/MARKDOWN_XSS.md
+++ b/docs/MARKDOWN_XSS.md
@@ -30,3 +30,11 @@ Repo file preview for `.html` (and PDF fallback) in
 - **PDF fallback iframe**: restrictive empty `sandbox=""` (no scripts). Native
   browser PDF viewers do not need `allow-scripts`; prefer this over leaving the
   iframe unsandboxed.
+
+## README relative images (Nostr / GRASP)
+
+Relative image paths in READMEs (e.g. `![…](docs/assets/foo.png)`) must **display**
+on Nostr-native / GRASP repos via same-origin file APIs — see
+`ui/src/lib/repos/resolve-readme-markdown-image.ts` and
+`ReadmeMarkdownImage`. Do not invent forge `/raw/` URLs for `git.gittr.space`.
+Blossom is only for hosted media outside the git tree, not for in-repo README assets.

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,8 +9,7 @@
     "start": "next start",
     "prettier": "prettier src/**/*.{ts,tsx} --write",
     "eslint": "eslint --ext .ts,.tsx --fix .",
-    "test:unit": "npx vitest run src/lib/git/bare-repo-tree-last-commits.test.ts src/lib/utils/filter-display-clone-urls.test.ts src/lib/nostr/should-announce-upstream-tip.test.ts src/lib/repos/repo-file-tree-branch.test.ts src/lib/repos/forge-tree-shrink.test.ts src/lib/repos/select-display-file-tree.test.ts src/lib/security/markdown-rehype-plugins.test.ts src/lib/ui/list-pagination.test.ts",
-    "test:regressions": "npm run test:unit",
+    "test:unit": "npx vitest run src/lib/git/bare-repo-tree-last-commits.test.ts src/lib/utils/filter-display-clone-urls.test.ts src/lib/nostr/should-announce-upstream-tip.test.ts src/lib/repos/repo-file-tree-branch.test.ts src/lib/repos/forge-tree-shrink.test.ts src/lib/repos/select-display-file-tree.test.ts src/lib/security/markdown-rehype-plugins.test.ts src/lib/ui/list-pagination.test.ts src/lib/repos/resolve-readme-markdown-image.test.ts",    "test:regressions": "npm run test:unit",
     "delete:nostr-relaypool-ts": "rimraf ./node_modules/nostr-relaypool/*.ts",
     "generate-system-keypair": "node scripts/generate-system-keypair.js"
   },

--- a/ui/src/components/repo/ReadmeMarkdownImage.tsx
+++ b/ui/src/components/repo/ReadmeMarkdownImage.tsx
@@ -1,129 +1,222 @@
 "use client";
 
+import {
+  mimeForRepoImagePath,
+  resolveReadmeMarkdownImage,
+} from "@/lib/repos/resolve-readme-markdown-image";
 import { useEffect, useState } from "react";
 
 type Props = {
   alt?: string;
-  primarySrc: string;
-  /** Relative path in the repo (for same-origin API fallback). */
-  repoPath?: string;
-  sourceUrl?: string;
+  /** Raw markdown `src` (relative or absolute). */
+  src?: string;
   branch?: string;
+  forgeSourceUrl?: string | null;
+  cloneUrls?: string[] | null;
+  ownerPubkey?: string | null;
+  repoName?: string | null;
   className?: string;
 };
 
+type FetchOk = { dataUrl: string };
+
+async function fetchViaGitFileContent(
+  sourceUrl: string,
+  path: string,
+  branch: string
+): Promise<FetchOk | null> {
+  const q = new URLSearchParams({
+    sourceUrl: sourceUrl.replace(/\.git$/, ""),
+    path,
+    branch,
+  });
+  const res = await fetch(`/api/git/file-content?${q.toString()}`);
+  if (!res.ok) return null;
+  const data = (await res.json()) as { content?: string; isBinary?: boolean };
+  if (!data.content) return null;
+  const mime = mimeForRepoImagePath(path);
+  if (data.isBinary) {
+    return {
+      dataUrl: `data:${mime};base64,${data.content.replace(/\s/g, "")}`,
+    };
+  }
+  if (mime === "image/svg+xml") {
+    return {
+      dataUrl: `data:${mime};charset=utf-8,${encodeURIComponent(data.content)}`,
+    };
+  }
+  return {
+    dataUrl: `data:${mime};base64,${btoa(data.content)}`,
+  };
+}
+
+async function fetchViaNostrBridge(
+  ownerPubkey: string,
+  repo: string,
+  path: string,
+  branch: string
+): Promise<FetchOk | null> {
+  const q = new URLSearchParams({
+    ownerPubkey,
+    repo,
+    path,
+    branch,
+  });
+  const res = await fetch(`/api/nostr/repo/file-content?${q.toString()}`);
+  if (!res.ok) return null;
+  const data = (await res.json()) as { content?: string; isBinary?: boolean };
+  if (!data.content) return null;
+  const mime = mimeForRepoImagePath(path);
+  if (data.isBinary) {
+    return {
+      dataUrl: `data:${mime};base64,${data.content.replace(/\s/g, "")}`,
+    };
+  }
+  if (mime === "image/svg+xml") {
+    return {
+      dataUrl: `data:${mime};charset=utf-8,${encodeURIComponent(data.content)}`,
+    };
+  }
+  return {
+    dataUrl: `data:${mime};base64,${btoa(data.content)}`,
+  };
+}
+
 /**
- * README images often point at raw.githubusercontent.com. Some browsers / Brave
- * shields fail those hotlinks (especially SVG). Fall back to our file-content API
- * (same origin) and render a data URL.
+ * README images: relative paths (e.g. docs/assets/*.png) must render on
+ * Nostr-native / GRASP repos via same-origin file APIs — not invent /raw/ URLs
+ * and not require Blossom for in-repo assets.
  */
 export function ReadmeMarkdownImage({
   alt = "",
-  primarySrc,
-  repoPath,
-  sourceUrl,
+  src = "",
   branch = "main",
+  forgeSourceUrl,
+  cloneUrls,
+  ownerPubkey,
+  repoName,
   className = "max-w-full h-auto rounded",
 }: Props) {
-  const [src, setSrc] = useState(primarySrc);
-  const [triedApi, setTriedApi] = useState(false);
+  const [displaySrc, setDisplaySrc] = useState("");
+  const [apiTried, setApiTried] = useState(false);
+  const [meta, setMeta] = useState(() =>
+    resolveReadmeMarkdownImage({
+      src,
+      branch,
+      forgeSourceUrl,
+      cloneUrls,
+      ownerPubkey,
+      repoName,
+    })
+  );
 
   useEffect(() => {
-    setSrc(primarySrc);
-    setTriedApi(false);
-  }, [primarySrc, repoPath, sourceUrl, branch]);
+    const next = resolveReadmeMarkdownImage({
+      src,
+      branch,
+      forgeSourceUrl,
+      cloneUrls,
+      ownerPubkey,
+      repoName,
+    });
+    setMeta(next);
+    setDisplaySrc(next?.primarySrc || "");
+    setApiTried(false);
+  }, [src, branch, forgeSourceUrl, cloneUrls, ownerPubkey, repoName]);
 
   useEffect(() => {
-    if (!src || triedApi || !repoPath || !sourceUrl) return;
-    // Prefer same-origin for SVG up front — raw GitHub SVG often fails as <img> in Brave.
-    if (!/\.svg(\?|#|$)/i.test(repoPath) && !/\.svg(\?|#|$)/i.test(primarySrc)) {
-      return;
-    }
+    if (!meta?.repoPath || apiTried) return;
+    const needsApi =
+      meta.preferApi ||
+      !meta.primarySrc ||
+      /\.svg(\?|#|$)/i.test(meta.repoPath);
+
+    if (!needsApi && meta.primarySrc) return;
+
     let cancelled = false;
     (async () => {
       try {
-        const q = new URLSearchParams({
-          sourceUrl: sourceUrl.replace(/\.git$/, ""),
-          path: repoPath,
-          branch,
-        });
-        const res = await fetch(`/api/git/file-content?${q.toString()}`);
-        if (!res.ok) return;
-        const data = (await res.json()) as {
-          content?: string;
-          isBinary?: boolean;
-        };
-        if (!data.content || cancelled) return;
-        const b64 = data.content.replace(/\s/g, "");
-        const dataUrl = data.isBinary
-          ? `data:image/svg+xml;base64,${b64}`
-          : `data:image/svg+xml;charset=utf-8,${encodeURIComponent(data.content)}`;
-        setTriedApi(true);
-        setSrc(dataUrl);
+        let ok: FetchOk | null = null;
+        if (meta.sourceUrl) {
+          ok = await fetchViaGitFileContent(
+            meta.sourceUrl,
+            meta.repoPath!,
+            branch
+          );
+        }
+        if (!ok && meta.ownerPubkey && meta.repoName) {
+          ok = await fetchViaNostrBridge(
+            meta.ownerPubkey,
+            meta.repoName,
+            meta.repoPath!,
+            branch
+          );
+        }
+        if (!cancelled) {
+          setApiTried(true);
+          if (ok?.dataUrl) setDisplaySrc(ok.dataUrl);
+        }
       } catch {
-        /* keep primarySrc; onError may retry */
+        if (!cancelled) setApiTried(true);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [src, triedApi, repoPath, sourceUrl, branch, primarySrc]);
+  }, [
+    apiTried,
+    branch,
+    meta?.preferApi,
+    meta?.primarySrc,
+    meta?.repoPath,
+    meta?.sourceUrl,
+    meta?.ownerPubkey,
+    meta?.repoName,
+  ]);
 
-  if (!src) return null;
+  if (!meta) return null;
+  if (!displaySrc && !meta.preferApi) return null;
+  if (!displaySrc) {
+    return (
+      <span className="text-sm text-gray-500 italic" title={meta.repoPath}>
+        {alt || "Loading image…"}
+      </span>
+    );
+  }
 
   return (
     <img
-      src={src}
+      src={displaySrc}
       alt={alt}
       className={className}
       style={{ maxWidth: "100%", width: "auto", height: "auto" }}
       onError={async () => {
-        if (triedApi || !repoPath || !sourceUrl) {
-          console.warn("⚠️ [README] Image failed to load:", primarySrc);
+        if (apiTried || !meta.repoPath) {
+          console.warn("⚠️ [README] Image failed to load:", src);
           return;
         }
-        setTriedApi(true);
+        setApiTried(true);
         try {
-          const q = new URLSearchParams({
-            sourceUrl: sourceUrl.replace(/\.git$/, ""),
-            path: repoPath,
-            branch,
-          });
-          const res = await fetch(`/api/git/file-content?${q.toString()}`);
-          if (!res.ok) {
-            console.warn("⚠️ [README] Image failed to load:", primarySrc);
-            return;
-          }
-          const data = (await res.json()) as {
-            content?: string;
-            isBinary?: boolean;
-          };
-          if (!data.content) {
-            console.warn("⚠️ [README] Image failed to load:", primarySrc);
-            return;
-          }
-          const ext = (repoPath.split(".").pop() || "").toLowerCase();
-          const mime =
-            ext === "svg"
-              ? "image/svg+xml"
-              : ext === "png"
-                ? "image/png"
-                : ext === "jpg" || ext === "jpeg"
-                  ? "image/jpeg"
-                  : ext === "gif"
-                    ? "image/gif"
-                    : ext === "webp"
-                      ? "image/webp"
-                      : "application/octet-stream";
-          if (data.isBinary) {
-            setSrc(`data:${mime};base64,${data.content.replace(/\s/g, "")}`);
-          } else {
-            setSrc(
-              `data:${mime};charset=utf-8,${encodeURIComponent(data.content)}`
+          let ok: FetchOk | null = null;
+          if (meta.sourceUrl) {
+            ok = await fetchViaGitFileContent(
+              meta.sourceUrl,
+              meta.repoPath,
+              branch
             );
           }
+          if (!ok && meta.ownerPubkey && meta.repoName) {
+            ok = await fetchViaNostrBridge(
+              meta.ownerPubkey,
+              meta.repoName,
+              meta.repoPath,
+              branch
+            );
+          }
+          if (ok?.dataUrl) setDisplaySrc(ok.dataUrl);
+          else console.warn("⚠️ [README] Image failed to load:", src);
         } catch {
-          console.warn("⚠️ [README] Image failed to load:", primarySrc);
+          console.warn("⚠️ [README] Image failed to load:", src);
         }
       }}
     />

--- a/ui/src/components/repo/RepoCodePage.tsx
+++ b/ui/src/components/repo/RepoCodePage.tsx
@@ -17788,126 +17788,33 @@ export function RepoCodePage() {
                         ...readmeHeadingComponents,
                         ...markdownProseCodeSafeComponents,
                         img: ({ node, ...props }) => {
-                          // Transform relative image paths to absolute URLs
-                          let imageSrc = props.src || "";
-                          let imagePath = "";
                           const branch =
                             selectedBranch || repoData?.defaultBranch || "main";
-                          const sourceUrl = (
+                          const forgeSourceUrl =
                             effectiveSourceUrl ||
                             repoData?.sourceUrl ||
-                            (Array.isArray(
-                              (repoData as { clone?: string[] } | null)?.clone
-                            )
-                              ? (repoData as { clone?: string[] }).clone?.find(
-                                  (u) => /github\.com/i.test(u)
-                                )
-                              : "") ||
-                            ""
-                          ).replace(/\.git$/, "");
-
-                          // If src is already an absolute URL (http:// or https://) or data URL, use it as-is
-                          if (
-                            imageSrc.startsWith("http://") ||
-                            imageSrc.startsWith("https://") ||
-                            imageSrc.startsWith("data:")
-                          ) {
-                            return (
-                              <div className="my-4 overflow-x-auto">
-                                <ReadmeMarkdownImage
-                                  primarySrc={imageSrc}
-                                  alt={props.alt || ""}
-                                  sourceUrl={sourceUrl || undefined}
-                                  branch={branch}
-                                />
-                              </div>
-                            );
-                          }
-
-                          // For relative paths, resolve them using the repository's sourceUrl or API
-                          if (imageSrc && repoData) {
-                            try {
-                              imagePath = imageSrc;
-                              if (imagePath.startsWith("./")) {
-                                imagePath = imagePath.slice(2);
-                              } else if (imagePath.startsWith("/")) {
-                                imagePath = imagePath.slice(1);
-                              }
-
-                              const githubMatch = sourceUrl.match(
-                                /github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?$/
-                              );
-                              const gitlabMatch = sourceUrl.match(
-                                /gitlab\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?$/
-                              );
-                              const codebergMatch = sourceUrl.match(
-                                /codeberg\.org\/([^\/]+)\/([^\/]+?)(?:\.git)?$/
-                              );
-
-                              if (githubMatch) {
-                                const [, owner, repo] = githubMatch;
-                                imageSrc = `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(
-                                  branch
-                                )}/${imagePath}`;
-                              } else if (gitlabMatch) {
-                                const [, owner, repo] = gitlabMatch;
-                                imageSrc = `https://gitlab.com/${owner}/${repo}/-/raw/${encodeURIComponent(
-                                  branch
-                                )}/${imagePath}`;
-                              } else if (codebergMatch) {
-                                const [, owner, repo] = codebergMatch;
-                                imageSrc = `https://codeberg.org/${owner}/${repo}/raw/branch/${encodeURIComponent(
-                                  branch
-                                )}/${imagePath}`;
-                              } else if (!sourceUrl) {
-                                imageSrc = "";
-                              } else {
-                                try {
-                                  const url = new URL(sourceUrl);
-                                  const pathParts = url.pathname
-                                    .split("/")
-                                    .filter(Boolean);
-                                  if (pathParts.length >= 2) {
-                                    const owner = pathParts[0];
-                                    const repo = pathParts[1];
-                                    imageSrc = `${url.protocol}//${
-                                      url.host
-                                    }/${owner}/${repo}/raw/${encodeURIComponent(
-                                      branch
-                                    )}/${imagePath}`;
-                                  } else {
-                                    console.warn(
-                                      "⚠️ [README] Could not parse sourceUrl for image:",
-                                      sourceUrl
-                                    );
-                                  }
-                                } catch (e) {
-                                  console.warn(
-                                    "⚠️ [README] Failed to construct raw URL for image:",
-                                    imageSrc,
-                                    e
-                                  );
-                                }
-                              }
-                            } catch (e) {
-                              console.warn(
-                                "⚠️ [README] Failed to resolve image URL:",
-                                imageSrc,
-                                e
-                              );
-                            }
-                          }
-
-                          if (!imageSrc) return null;
-
+                            null;
+                          const cloneUrls = Array.isArray(
+                            (repoData as { clone?: string[] } | null)?.clone
+                          )
+                            ? (repoData as { clone: string[] }).clone
+                            : null;
+                          const ownerPk =
+                            repoOwnerPubkey ||
+                            entityPubkey ||
+                            (repoData as { ownerPubkey?: string } | null)
+                              ?.ownerPubkey ||
+                            null;
                           return (
                             <div className="my-4 overflow-x-auto">
                               <ReadmeMarkdownImage
-                                primarySrc={imageSrc}
-                                repoPath={imagePath || undefined}
-                                sourceUrl={sourceUrl || undefined}
-                                branch={branch}
+                                src={props.src || ""}
                                 alt={props.alt || ""}
+                                branch={branch}
+                                forgeSourceUrl={forgeSourceUrl}
+                                cloneUrls={cloneUrls}
+                                ownerPubkey={ownerPk}
+                                repoName={decodedRepo}
                               />
                             </div>
                           );
@@ -18420,111 +18327,35 @@ export function RepoCodePage() {
                             ...fileHeadingComponents,
                             ...markdownProseCodeSafeComponents,
                             img: ({ node, ...props }) => {
-                              let imageSrc = props.src || "";
-                              let imagePath = "";
                               const branch =
                                 selectedBranch ||
                                 repoData?.defaultBranch ||
                                 "main";
-                              const sourceUrl = (
+                              const forgeSourceUrl =
                                 effectiveSourceUrl ||
                                 repoData?.sourceUrl ||
-                                ""
-                              ).replace(/\.git$/, "");
-
-                              if (
-                                imageSrc.startsWith("http://") ||
-                                imageSrc.startsWith("https://") ||
-                                imageSrc.startsWith("data:")
-                              ) {
-                                return (
-                                  <div className="my-4 overflow-x-auto">
-                                    <ReadmeMarkdownImage
-                                      primarySrc={imageSrc}
-                                      alt={props.alt || ""}
-                                      sourceUrl={sourceUrl || undefined}
-                                      branch={branch}
-                                    />
-                                  </div>
-                                );
-                              }
-
-                              if (imageSrc && repoData) {
-                                try {
-                                  imagePath = imageSrc;
-                                  if (imagePath.startsWith("./")) {
-                                    imagePath = imagePath.slice(2);
-                                  } else if (imagePath.startsWith("/")) {
-                                    imagePath = imagePath.slice(1);
-                                  }
-
-                                  const githubMatch = sourceUrl.match(
-                                    /github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?$/
-                                  );
-                                  const gitlabMatch = sourceUrl.match(
-                                    /gitlab\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?$/
-                                  );
-                                  const codebergMatch = sourceUrl.match(
-                                    /codeberg\.org\/([^\/]+)\/([^\/]+?)(?:\.git)?$/
-                                  );
-
-                                  if (githubMatch) {
-                                    const [, owner, repo] = githubMatch;
-                                    imageSrc = `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(
-                                      branch
-                                    )}/${imagePath}`;
-                                  } else if (gitlabMatch) {
-                                    const [, owner, repo] = gitlabMatch;
-                                    imageSrc = `https://gitlab.com/${owner}/${repo}/-/raw/${encodeURIComponent(
-                                      branch
-                                    )}/${imagePath}`;
-                                  } else if (codebergMatch) {
-                                    const [, owner, repo] = codebergMatch;
-                                    imageSrc = `https://codeberg.org/${owner}/${repo}/raw/branch/${encodeURIComponent(
-                                      branch
-                                    )}/${imagePath}`;
-                                  } else if (sourceUrl) {
-                                    try {
-                                      const url = new URL(sourceUrl);
-                                      const pathParts = url.pathname
-                                        .split("/")
-                                        .filter(Boolean);
-                                      if (pathParts.length >= 2) {
-                                        const owner = pathParts[0];
-                                        const repo = pathParts[1];
-                                        imageSrc = `${url.protocol}//${
-                                          url.host
-                                        }/${owner}/${repo}/raw/${encodeURIComponent(
-                                          branch
-                                        )}/${imagePath}`;
-                                      }
-                                    } catch (e) {
-                                      console.warn(
-                                        "⚠️ [README] Failed to construct raw URL for image:",
-                                        imageSrc,
-                                        e
-                                      );
-                                    }
-                                  }
-                                } catch (e) {
-                                  console.warn(
-                                    "⚠️ [README] Failed to resolve image URL:",
-                                    imageSrc,
-                                    e
-                                  );
-                                }
-                              }
-
-                              if (!imageSrc) return null;
-
+                                null;
+                              const cloneUrls = Array.isArray(
+                                (repoData as { clone?: string[] } | null)?.clone
+                              )
+                                ? (repoData as { clone: string[] }).clone
+                                : null;
+                              const ownerPk =
+                                repoOwnerPubkey ||
+                                entityPubkey ||
+                                (repoData as { ownerPubkey?: string } | null)
+                                  ?.ownerPubkey ||
+                                null;
                               return (
                                 <div className="my-4 overflow-x-auto">
                                   <ReadmeMarkdownImage
-                                    primarySrc={imageSrc}
-                                    repoPath={imagePath || undefined}
-                                    sourceUrl={sourceUrl || undefined}
-                                    branch={branch}
+                                    src={props.src || ""}
                                     alt={props.alt || ""}
+                                    branch={branch}
+                                    forgeSourceUrl={forgeSourceUrl}
+                                    cloneUrls={cloneUrls}
+                                    ownerPubkey={ownerPk}
+                                    repoName={decodedRepo}
                                   />
                                 </div>
                               );

--- a/ui/src/lib/repos/resolve-readme-markdown-image.test.ts
+++ b/ui/src/lib/repos/resolve-readme-markdown-image.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeRepoRelPath,
+  resolveReadmeMarkdownImage,
+} from "./resolve-readme-markdown-image";
+
+describe("resolveReadmeMarkdownImage", () => {
+  it("normalizes relative asset paths", () => {
+    expect(normalizeRepoRelPath("./docs/assets/a.png")).toBe(
+      "docs/assets/a.png"
+    );
+    expect(normalizeRepoRelPath("/docs/assets/a.png")).toBe("docs/assets/a.png");
+    expect(normalizeRepoRelPath("../secret")).toBe("");
+  });
+
+  it("keeps absolute https URLs", () => {
+    const r = resolveReadmeMarkdownImage({
+      src: "https://example.com/x.png",
+      branch: "main",
+    });
+    expect(r?.primarySrc).toBe("https://example.com/x.png");
+    expect(r?.preferApi).toBe(false);
+  });
+
+  it("maps GitHub relative paths to raw.githubusercontent.com", () => {
+    const r = resolveReadmeMarkdownImage({
+      src: "docs/assets/dashboard-map.png",
+      branch: "main",
+      forgeSourceUrl: "https://github.com/acme/lab-kit.git",
+    });
+    expect(r?.preferApi).toBe(false);
+    expect(r?.primarySrc).toContain("raw.githubusercontent.com/acme/lab-kit");
+    expect(r?.primarySrc).toContain("docs/assets/dashboard-map.png");
+    expect(r?.repoPath).toBe("docs/assets/dashboard-map.png");
+  });
+
+  it("uses same-origin API for Nostr/GRASP clones (no invented /raw/)", () => {
+    const r = resolveReadmeMarkdownImage({
+      src: "docs/assets/dashboard-map.png",
+      branch: "main",
+      cloneUrls: [
+        "https://git.gittr.space/npub1abcxyz/lab-kit.git",
+      ],
+      ownerPubkey: "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+      repoName: "lab-kit",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.preferApi).toBe(true);
+    expect(r!.primarySrc).toBe("");
+    expect(r!.repoPath).toBe("docs/assets/dashboard-map.png");
+    expect(r!.sourceUrl).toContain("git.gittr.space");
+    expect(r!.primarySrc.includes("/raw/")).toBe(false);
+  });
+
+  it("falls back to ownerPubkey+repo when no clone URL", () => {
+    const r = resolveReadmeMarkdownImage({
+      src: "docs/assets/board.png",
+      branch: "master",
+      ownerPubkey: "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+      repoName: "lab-kit",
+    });
+    expect(r?.preferApi).toBe(true);
+    expect(r?.ownerPubkey).toHaveLength(64);
+    expect(r?.repoName).toBe("lab-kit");
+  });
+
+  it("returns null when relative and no fetch identity", () => {
+    expect(
+      resolveReadmeMarkdownImage({
+        src: "docs/assets/x.png",
+        branch: "main",
+      })
+    ).toBeNull();
+  });
+});

--- a/ui/src/lib/repos/resolve-readme-markdown-image.ts
+++ b/ui/src/lib/repos/resolve-readme-markdown-image.ts
@@ -1,0 +1,133 @@
+/**
+ * Resolve README / markdown image src for forge + Nostr-native (GRASP) repos.
+ * Relative paths like `docs/assets/foo.png` must show on gittr without Blossom.
+ */
+export type ReadmeImageResolveInput = {
+  src: string;
+  branch: string;
+  /** Upstream forge URL when known (GitHub / GitLab / Codeberg). */
+  forgeSourceUrl?: string | null;
+  /** clone: tags — may include https://git.gittr.space/npub…/repo.git */
+  cloneUrls?: string[] | null;
+  ownerPubkey?: string | null;
+  repoName?: string | null;
+};
+
+export type ReadmeImageResolveResult = {
+  /** Hotlink when forge raw works; empty when we must fetch via same-origin API. */
+  primarySrc: string;
+  repoPath?: string;
+  sourceUrl?: string;
+  ownerPubkey?: string;
+  repoName?: string;
+  /** Load via /api immediately (Nostr / GRASP — no real /raw/ URL). */
+  preferApi: boolean;
+};
+
+const FORGE_RAW: Array<{
+  re: RegExp;
+  raw: (owner: string, repo: string, branch: string, path: string) => string;
+}> = [
+  {
+    re: /github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/i,
+    raw: (o, r, b, p) =>
+      `https://raw.githubusercontent.com/${o}/${r}/${encodeURIComponent(b)}/${p}`,
+  },
+  {
+    re: /gitlab\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/i,
+    raw: (o, r, b, p) =>
+      `https://gitlab.com/${o}/${r}/-/raw/${encodeURIComponent(b)}/${p}`,
+  },
+  {
+    re: /codeberg\.org\/([^/]+)\/([^/]+?)(?:\.git)?$/i,
+    raw: (o, r, b, p) =>
+      `https://codeberg.org/${o}/${r}/raw/branch/${encodeURIComponent(b)}/${p}`,
+  },
+];
+
+export function normalizeRepoRelPath(src: string): string {
+  let p = (src || "").trim();
+  if (p.startsWith("./")) p = p.slice(2);
+  if (p.startsWith("/")) p = p.slice(1);
+  // Block path escape theater
+  if (p.includes("..") || p.startsWith("~")) return "";
+  return p;
+}
+
+function pickCloneUrl(clones: string[] | null | undefined): string {
+  if (!Array.isArray(clones)) return "";
+  for (const raw of clones) {
+    if (typeof raw !== "string") continue;
+    const u = raw.trim().replace(/\.git$/, "");
+    if (/^https?:\/\//i.test(u)) return u;
+  }
+  return "";
+}
+
+/**
+ * Build display props for README images. Never invent GRASP `/raw/…` URLs —
+ * those 404; use same-origin file-content (preferApi) instead.
+ */
+export function resolveReadmeMarkdownImage(
+  input: ReadmeImageResolveInput
+): ReadmeImageResolveResult | null {
+  const src = (input.src || "").trim();
+  if (!src) return null;
+
+  if (
+    src.startsWith("http://") ||
+    src.startsWith("https://") ||
+    src.startsWith("data:")
+  ) {
+    return { primarySrc: src, preferApi: false };
+  }
+
+  const repoPath = normalizeRepoRelPath(src);
+  if (!repoPath) return null;
+
+  const branch = input.branch || "main";
+  const forge = (input.forgeSourceUrl || "").replace(/\.git$/, "").trim();
+  const clone = pickCloneUrl(input.cloneUrls);
+  const ownerPubkey = (input.ownerPubkey || "").trim() || undefined;
+  const repoName =
+    (input.repoName || "").trim().replace(/\.git$/, "") || undefined;
+
+  for (const f of FORGE_RAW) {
+    const m = forge.match(f.re);
+    if (m) {
+      const [, owner, repo] = m;
+      return {
+        primarySrc: f.raw(owner, repo.replace(/\.git$/, ""), branch, repoPath),
+        repoPath,
+        sourceUrl: forge,
+        preferApi: false,
+      };
+    }
+  }
+
+  // Nostr / GRASP / self-hosted: load via API (clone URL or ownerPubkey+repo)
+  const sourceUrl = clone || forge || undefined;
+  if (sourceUrl || (ownerPubkey && repoName)) {
+    return {
+      primarySrc: "",
+      repoPath,
+      sourceUrl,
+      ownerPubkey,
+      repoName,
+      preferApi: true,
+    };
+  }
+
+  return null;
+}
+
+export function mimeForRepoImagePath(path: string): string {
+  const ext = (path.split(".").pop() || "").toLowerCase();
+  if (ext === "svg") return "image/svg+xml";
+  if (ext === "png") return "image/png";
+  if (ext === "jpg" || ext === "jpeg") return "image/jpeg";
+  if (ext === "gif") return "image/gif";
+  if (ext === "webp") return "image/webp";
+  if (ext === "ico") return "image/x-icon";
+  return "application/octet-stream";
+}


### PR DESCRIPTION
## Summary
- Relative README images (`docs/assets/…`) now load on Nostr-native / `git.gittr.space` repos via same-origin file APIs instead of inventing broken forge `/raw/` URLs or requiring Blossom.
- GitHub / GitLab / Codeberg still use normal raw hotlinks, with the existing API fallback.
- Adds `resolve-readme-markdown-image` helper + unit tests; documents the rule in `docs/MARKDOWN_XSS.md`.

## Test plan
- [ ] `cd ui && npx vitest run src/lib/repos/resolve-readme-markdown-image.test.ts`
- [ ] Open a Nostr-only repo README that uses `![…](docs/assets/….png)` — images should render
- [ ] Open a GitHub-mirrored repo README with relative images — still works via raw.githubusercontent.com
- [ ] Absolute `https://…` images still render


Made with [Cursor](https://cursor.com)